### PR TITLE
fix maker error

### DIFF
--- a/src/Maker/MakeAutocompleteField.php
+++ b/src/Maker/MakeAutocompleteField.php
@@ -131,7 +131,7 @@ EOF)
         );
         $generator->generateClass(
             $classDetails->getFullName(),
-            __DIR__.'./skeletons/AutocompleteField.tpl.php',
+            __DIR__.'/skeletons/AutocompleteField.tpl.php',
             [
                 'variables' => $variables,
             ]


### PR DESCRIPTION
extra dot at the beginning. Because of it, when you run the command make:autocomplete-field, an error occurs - Cannot find template "/var/www/vhosts/8.1/synapse/vendor/symfony/ux-autocomplete/src/Maker./skeletons/AutocompleteField.tpl.php"