### PR TITLE
Allow removing options that `EntityType` can't accept

### DIFF
--- a/src/Form/AutocompleteEntityTypeSubscriber.php
+++ b/src/Form/AutocompleteEntityTypeSubscriber.php
@@ -43,9 +43,8 @@ final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
         // pass to AutocompleteChoiceTypeExtension
         $options['autocomplete'] = true;
         $options['autocomplete_url'] = $this->autocompleteUrl;
-        unset($options['searchable_fields'], $options['security'], $options['filter_query']);
 
-        $form->add('autocomplete', EntityType::class, $options);
+        $form->add('autocomplete', EntityType::class, $this->removeBlacklistedOptions($options));
     }
 
     public function preSubmit(FormEvent $event)
@@ -103,5 +102,30 @@ final class AutocompleteEntityTypeSubscriber implements EventSubscriberInterface
             FormEvents::PRE_SET_DATA => 'preSetData',
             FormEvents::PRE_SUBMIT => 'preSubmit',
         ];
+    }
+
+    /**
+     * If you create a custom Form Type based on {@link ParentEntityAutocompleteType} and make it accept any non-standard
+     * options, these options need to be removed from the $options array passed to EntityType because it doesn't
+     * accept those custom options.
+     *
+     * @see https://github.com/symfony/ux/issues/420
+     */
+    private function removeBlacklistedOptions(array $options): array
+    {
+        $optionBlacklist = [
+            // Options added by ParentEntityAutocompleteType
+            'searchable_fields', 'security', 'filter_query', 'property',
+            // Any other options that were added to the custom AutocompleteType that EntityType doesn't understand
+            ...$options['autocomplete_blacklist'],
+            // The list of blacklisted options itself (EntityType doesn't understand that either!)
+            'autocomplete_blacklist'
+        ];
+
+        foreach ($optionBlacklist as $option) {
+            unset($options[$option]);
+        }
+
+        return $options;
     }
 }

--- a/src/Form/ParentEntityAutocompleteType.php
+++ b/src/Form/ParentEntityAutocompleteType.php
@@ -82,6 +82,8 @@ final class ParentEntityAutocompleteType extends AbstractType implements DataMap
             'security' => false,
             // set the max results number that a query on automatic endpoint return.
             'max_results' => 10,
+            /** @see AutocompleteEntityTypeSubscriber::removeBlacklistedOptions() */
+            'autocomplete_blacklist' => [],
         ]);
 
         $resolver->setRequired(['class']);


### PR DESCRIPTION
See https://github.com/symfony/ux/issues/420

I'm not married to the `autocomplete_blacklist` name. Feel free to change it if you think something else fits better. 

Also, the docs need updating. I'm happy to do that if this idea gets enough support to be merged. 