### PR TITLE
added getGroupBy function into AutoComplete with no Form

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -464,6 +464,11 @@ and tag this service with ``ux.entity_autocompleter``, including an ``alias`` op
             return $entity->getId();
         }
 
+        public function getGroupBy(): mixed
+        {
+            return null;
+        }
+
         public function isGranted(Security $security): bool
         {
             // see the "security" option for details


### PR DESCRIPTION
Fix "Class "App\Autocomplete\****Autocompleter" should implement method "Symfony\UX\Autocomplete\EntityAutocompleterInterface::getGroupBy(): mixed": Return group_by option." deprecation message.